### PR TITLE
HP Admin API: return latest HoloPortOS version, add manual upgrade endpoint

### DIFF
--- a/2019-09-16-hp-admin-api.md
+++ b/2019-09-16-hp-admin-api.md
@@ -123,9 +123,7 @@ Prints immutable HoloPort status data. `zerotier` field is verbatim `zerotier-cl
 
 ### `POST /v1/upgrade`
 
-Forces an os version upgrade, which maps onto `nixos-rebuild --upgrade switch`
-
-No params passed. There's a world where we pass the os-version and it installs that, but that's beyond hAppy team needs for launch.
+Forces HoloPortOS upgrade.
 
 #### `200 OK`
 #### `400 Bad Request`

--- a/2019-09-16-hp-admin-api.md
+++ b/2019-09-16-hp-admin-api.md
@@ -108,9 +108,9 @@ Prints immutable HoloPort status data.
 }
 ```
 
-### `POST /v1/update-os`
+### `POST /v1/upgrade`
 
-Forces an os version updates.
+Forces an os version upgrade, which maps onto `nixos-rebuild --upgrade switch`
 
 No params passed. There's a world where we pass the os-version and it installs that, but that's beyond hAppy team needs for launch.
 

--- a/2019-09-16-hp-admin-api.md
+++ b/2019-09-16-hp-admin-api.md
@@ -36,9 +36,7 @@ Returns `holo-config.json` data with `seed` field filtered out.
     },
     "holoportos": {
         "network": "live",
-        "sshAccess": true,
-        "os_version": "1.2.3",
-        "os_latest": "1.3.0"
+        "sshAccess": true
     },
     "name": "My HoloPort"
 }
@@ -86,13 +84,19 @@ Updates `holo-config.json`.
 
 #### `200 OK`
 
-Prints immutable HoloPort status data. `zerotier` field is verbatim `zerotier-cli -j info` output.
+Prints immutable HoloPort status data.
+
+- `holo_nixpkgs.revs.channel` is the latest HoloPortOS version
+- `holo_nixpkgs.revs.current_system` is currently installed HoloPortOS version
+- `zerotier` field is verbatim `zerotier-cli -j info` output
 
 ```json
 {
     "holo_nixpkgs": {
-      "url": "https://hydra.holo.host/channel/custom/holo-nixpkgs/develop/holo-nixpkgs",
-      "rev": "b13891c28d78f1e916fdefb5edc1d386e4f533c8",
+        "revs": {
+            "channel": "b13891c28d78f1e916fdefb5edc1d386e4f533c8",
+            "current_system": "4707080a5cba68e8bc215e22ef1c8e7d8e70791b"
+        }
     },
     "zerotier": {
         "address": "2f07044b7a",  

--- a/2019-09-16-hp-admin-api.md
+++ b/2019-09-16-hp-admin-api.md
@@ -93,9 +93,11 @@ Prints immutable HoloPort status data.
 ```json
 {
     "holo_nixpkgs": {
-        "revs": {
-            "channel": "b13891c28d78f1e916fdefb5edc1d386e4f533c8",
-            "current_system": "4707080a5cba68e8bc215e22ef1c8e7d8e70791b"
+        "channel": {
+            "rev": "b13891c28d78f1e916fdefb5edc1d386e4f533c8"
+        },
+        "current_system": {
+            "rev": "4707080a5cba68e8bc215e22ef1c8e7d8e70791b"
         }
     },
     "zerotier": {

--- a/2019-09-16-hp-admin-api.md
+++ b/2019-09-16-hp-admin-api.md
@@ -128,9 +128,6 @@ Forces an os version upgrade, which maps onto `nixos-rebuild --upgrade switch`
 No params passed. There's a world where we pass the os-version and it installs that, but that's beyond hAppy team needs for launch.
 
 #### `200 OK`
-
-Returns the same `holo-config.json` file as `/v1/config`
-
 #### `400 Bad Request`
 #### `401 Unauthorized`
 

--- a/2019-09-16-hp-admin-api.md
+++ b/2019-09-16-hp-admin-api.md
@@ -44,7 +44,9 @@ Returns `holo-config.json` data with `seed` field filtered out.
     },
     "holoportos": {
         "network": "live",
-        "sshAccess": true
+        "sshAccess": true,
+        "os_version": "1.2.3",
+        "os_latest": "1.3.0"
     },
     "name": "My HoloPort"
 }
@@ -104,3 +106,17 @@ Prints immutable HoloPort status data.
         // `zerotier-cli -j info` output
     }    
 }
+```
+
+### `POST /v1/update-os`
+
+Forces an os version updates.
+
+No params passed. There's a world where we pass the os-version and it installs that, but that's beyond hAppy team needs for launch.
+
+#### `200 OK`
+
+Returns the same `holo-config.json` file as `/v1/config`
+
+#### `400 Bad Request`
+#### `401 Unauthorized`


### PR DESCRIPTION
Additional fields and endpoint for displaying os version and updating it manually.

`os_version` is the current version of `hpos` installed on the holoport, `os_latest` is the latest installable version.

I'm not attached to any of the names if you want to change them. How does this look @peeech?