### PR TITLE
Add wormhole port to transport layer reservations

### DIFF
--- a/2019-11-03-hp-nginx/README.md
+++ b/2019-11-03-hp-nginx/README.md
@@ -74,6 +74,11 @@ of English telephone keypads (eg. https://phonespell.org).
 - HTTP
 - WebSocket
 
+### `localhost:9676 "worm"` Wormhole
+
+**Supported protocols**
+- HTTP
+
 ### `localhost:23646 "admin"` Admin Server
 
 **Supported protocols**


### PR DESCRIPTION
I forgot about the HTTP server that Envoy runs to receive wormhole signing requests from Conductor